### PR TITLE
Adds option to set origin index

### DIFF
--- a/src/logger-options.ts
+++ b/src/logger-options.ts
@@ -2,4 +2,5 @@ export interface LoggerOptions {
   includeBlackList?: string[];
   excludeBlackList?: string[];
   whiteList?: string[];
+  originIndex?: number;
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -16,6 +16,8 @@ export class Logger {
 
   private readonly level: string;
 
+  private readonly originIndex: number;
+
   private readonly filter: LoggerFilter;
 
   public constructor(context?: object, options?: LoggerOptions) {
@@ -29,6 +31,7 @@ export class Logger {
       options?.excludeBlackList,
       options?.whiteList
     );
+    this.originIndex = options?.originIndex ?? 3;
   }
 
   public debug(message: string, extra?: object): void {
@@ -72,7 +75,7 @@ export class Logger {
   }
 
   protected getOrigin(): string {
-    const origin = callSites()[3];
+    const origin = callSites()[this.originIndex];
 
     const methodName = origin.getMethodName();
     if (methodName !== null) {


### PR DESCRIPTION
Para permitir que o usuário da biblioteca consiga logar o nome dos métodos/classes que chamam os métodos de log para níveis de stack maior que 3, adicionamos a opção originIndex e alteramos o callSites para usar esta opção quando a mesma está disponível